### PR TITLE
Add sort mode indicator in breadcrumb bar (#56)

### DIFF
--- a/src/ui/breadcrumb.rs
+++ b/src/ui/breadcrumb.rs
@@ -71,6 +71,12 @@ pub fn render_pane(f: &mut Frame, app: &App, pane_idx: usize, area: Rect, show_c
         spans.push(Span::styled("  ", Style::default()));
     }
 
+    // Sort indicator (#56)
+    spans.push(Span::styled(
+        format!(" SORT:{}", app.sort_mode.label()),
+        Style::default().fg(pal.text_dim),
+    ));
+
     // Use pulsed border color for active pane (#18)
     let border_color = if show_cursor { app.pulsed_border() } else { pal.border_dim };
     let block = Block::default()


### PR DESCRIPTION
## Summary
- Append sort indicator badge (SORT:NAME↑, SORT:SIZE↓, etc.) after path segments in breadcrumb
- Uses `text_dim` color, consistent with existing breadcrumb styling

## Test plan
- [ ] Launch rem, verify sort indicator appears in breadcrumb
- [ ] Press `s` to cycle sort modes, verify indicator updates

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)