### PR TITLE
Add visual selection summary in sidebar (#55)

### DIFF
--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -12,6 +12,48 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
 
     let mut lines: Vec<Line> = Vec::new();
 
+    // Visual selection summary (#55)
+    if !app.visual_marks.is_empty() {
+        lines.push(Line::from(Span::styled(
+            " S E L E C T I O N   S U M M A R Y",
+            Style::default().fg(pal.text_dim).bg(pal.bg),
+        )));
+        let pane = app.pane();
+        let mut total_size: u64 = 0;
+        let mut file_count: usize = 0;
+        let mut dir_count: usize = 0;
+        for &idx in &app.visual_marks {
+            if let Some(entry) = pane.entries.get(idx) {
+                if entry.is_dir {
+                    dir_count += 1;
+                } else {
+                    file_count += 1;
+                    if let Some(s) = entry.size {
+                        total_size += s;
+                    }
+                }
+            }
+        }
+        lines.push(Line::from(vec![
+            Span::styled(" FILES ", Style::default().fg(pal.text_dim).bg(pal.bg)),
+            Span::styled(file_count.to_string(), Style::default().fg(pal.text_hot).bg(pal.bg)),
+        ]));
+        if dir_count > 0 {
+            lines.push(Line::from(vec![
+                Span::styled(" DIRS  ", Style::default().fg(pal.text_dim).bg(pal.bg)),
+                Span::styled(dir_count.to_string(), Style::default().fg(pal.text_hot).bg(pal.bg)),
+            ]));
+        }
+        lines.push(Line::from(vec![
+            Span::styled(" TOTAL ", Style::default().fg(pal.text_dim).bg(pal.bg)),
+            Span::styled(
+                crate::app::format_size(total_size),
+                Style::default().fg(pal.text_hot).bg(pal.bg),
+            ),
+        ]));
+        lines.push(Line::from(Span::raw("")));
+    }
+
     // SELECTION section
     lines.push(Line::from(Span::styled(
         " S E L E C T I O N",


### PR DESCRIPTION
## Summary
- Add SELECTION SUMMARY section to sidebar when visual marks are active
- Shows FILES count, DIRS count, and TOTAL aggregate size
- Summary disappears when all marks are cleared

## Test plan
- [ ] Enter visual mode (V), select multiple files/dirs
- [ ] Verify SELECTION SUMMARY appears with accurate counts
- [ ] Clear marks, verify summary disappears

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)