### PR TITLE
Add file permissions column in list view (#47)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -423,6 +423,7 @@ pub struct FsEntry {
     pub modified: Option<SystemTime>,
     pub is_symlink: bool,
     pub link_target: Option<String>,
+    pub permissions: Option<String>,
 }
 
 /// Animation for file deletion corruption effect (#35).
@@ -1036,6 +1037,7 @@ impl App {
                 modified: None,
                 is_symlink: false,
                 link_target: None,
+                permissions: None,
             }).collect();
             pane.cursor = 0;
             pane.scroll_offset = 0;

--- a/src/input.rs
+++ b/src/input.rs
@@ -389,6 +389,7 @@ fn build_tree(app: &mut App) {
                     modified: entry.modified,
                     is_symlink: entry.is_symlink,
                     link_target: entry.link_target.clone(),
+                    permissions: entry.permissions.clone(),
                 },
                 depth: 0,
                 expanded: false,
@@ -464,6 +465,7 @@ fn tree_toggle_expand(app: &mut App) {
                     modified,
                     is_symlink,
                     link_target,
+                    permissions: None,
                 });
             }
             // Sort: dirs first, then case-insensitive name

--- a/src/nav.rs
+++ b/src/nav.rs
@@ -38,6 +38,34 @@ impl App {
                     let is_dir = meta.as_ref().map_or(false, |m| m.is_dir());
                     let size = meta.as_ref().and_then(|m| if !m.is_dir() { Some(m.len()) } else { None });
                     let modified = meta.as_ref().and_then(|m| m.modified().ok());
+                    // Permissions (#47)
+                    let permissions = {
+                        #[cfg(unix)]
+                        {
+                            use std::os::unix::fs::PermissionsExt;
+                            meta.as_ref().map(|m| {
+                                let mode = m.permissions().mode();
+                                let perms = [
+                                    if mode & 0o400 != 0 { 'r' } else { '-' },
+                                    if mode & 0o200 != 0 { 'w' } else { '-' },
+                                    if mode & 0o100 != 0 { 'x' } else { '-' },
+                                    if mode & 0o040 != 0 { 'r' } else { '-' },
+                                    if mode & 0o020 != 0 { 'w' } else { '-' },
+                                    if mode & 0o010 != 0 { 'x' } else { '-' },
+                                    if mode & 0o004 != 0 { 'r' } else { '-' },
+                                    if mode & 0o002 != 0 { 'w' } else { '-' },
+                                    if mode & 0o001 != 0 { 'x' } else { '-' },
+                                ];
+                                perms.iter().collect::<String>()
+                            })
+                        }
+                        #[cfg(not(unix))]
+                        {
+                            meta.as_ref().map(|m| {
+                                if m.permissions().readonly() { "R".to_string() } else { "RW".to_string() }
+                            })
+                        }
+                    };
                     // Detect broken symlinks
                     let broken = is_symlink && meta.is_none();
                     pane.entries.push(FsEntry {
@@ -48,6 +76,7 @@ impl App {
                         modified,
                         is_symlink,
                         link_target,
+                        permissions,
                     });
                 }
                 // Sort: dirs first, then by current sort mode

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -63,12 +63,14 @@ pub fn render_pane(f: &mut Frame, app: &App, pane_idx: usize, area: Rect) {
     // Determine which columns to show
     let show_size = width >= 90;
     let show_type = width >= 80;
+    let show_perms = width >= 110;
 
     let size_col = if show_size { 9 } else { 0 };
     let type_col = if show_type { 5 } else { 0 };
+    let perms_col = if show_perms { 10 } else { 0 };
     let jump_col = 5;
     let sigil_col = 2;
-    let right_cols = size_col + type_col;
+    let right_cols = size_col + type_col + perms_col;
     let name_width = width.saturating_sub(jump_col + sigil_col + right_cols + 2);
 
     let visible_height = area.height as usize;
@@ -169,6 +171,15 @@ pub fn render_pane(f: &mut Frame, app: &App, pane_idx: usize, area: Rect) {
             icon_style = icon_style.add_modifier(Modifier::ITALIC);
         }
         spans.push(Span::styled(icon_text, icon_style));
+
+        // Permissions column (#47)
+        if show_perms {
+            let perm_str = entry.permissions.as_deref().unwrap_or("---");
+            spans.push(Span::styled(
+                format!("{:<10}", perm_str),
+                Style::default().fg(pal.text_dim).bg(row_bg),
+            ));
+        }
 
         // Name — check for Rename/Create mode inline editing
         let is_rename_row = is_active && is_cursor && app.mode == Mode::Rename;
@@ -590,6 +601,7 @@ pub fn render_rsearch(f: &mut Frame, app: &App, area: Rect) {
             modified: None,
             is_symlink: false,
             link_target: None,
+            permissions: None,
         };
         let icon = icon_for(&fake_entry, &app.symbols);
 


### PR DESCRIPTION
## Summary
- Add `permissions` field to FsEntry with platform-aware computation (rwxrwxrwx on Unix, R/RW on Windows)
- Show permissions column in list view when terminal width >= 110 chars
- Responsive design: column hidden on narrow terminals

## Test plan
- [ ] Verify permissions column appears at wide terminal widths
- [ ] Verify column hides at narrow widths
- [ ] Verify permissions display correctly for files and directories

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)