### PR TITLE
Add favorites / pinned directories (#54)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -687,6 +687,8 @@ pub struct App {
     pub layout_areas: LayoutAreas,
     // Command mode (#41)
     pub command_state: CommandState,
+    // Favorites / pinned directories (#54)
+    pub favorites: Vec<PathBuf>,
 }
 
 impl App {
@@ -772,6 +774,7 @@ impl App {
                 history: Vec::new(),
                 history_idx: None,
             },
+            favorites: Vec::new(),
         };
         app.load_entries();
         app.git_info = GitInfo::detect(&app.panes[0].current_dir);

--- a/src/favorites.rs
+++ b/src/favorites.rs
@@ -1,0 +1,33 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Default)]
+struct FavoritesFile {
+    #[serde(default)]
+    directories: Vec<String>,
+}
+
+pub fn favorites_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("rem").join("favorites.toml"))
+}
+
+pub fn load_favorites() -> Vec<PathBuf> {
+    let Some(path) = favorites_path() else { return Vec::new() };
+    let Ok(content) = std::fs::read_to_string(&path) else { return Vec::new() };
+    let Ok(file) = toml::from_str::<FavoritesFile>(&content) else { return Vec::new() };
+    file.directories.into_iter().map(PathBuf::from).collect()
+}
+
+pub fn save_favorites(favs: &[PathBuf]) {
+    let Some(path) = favorites_path() else { return };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let file = FavoritesFile {
+        directories: favs.iter().map(|p| p.to_string_lossy().into_owned()).collect(),
+    };
+    if let Ok(content) = toml::to_string_pretty(&file) {
+        let _ = std::fs::write(&path, content);
+    }
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -328,6 +328,29 @@ fn handle_normal(app: &mut App, key: KeyEvent) {
                 build_tree(app);
             }
         }
+        // Favorites toggle (#54)
+        (KeyModifiers::CONTROL, KeyCode::Char('f')) => {
+            let dir = app.pane().current_dir.clone();
+            if let Some(pos) = app.favorites.iter().position(|p| *p == dir) {
+                app.favorites.remove(pos);
+                app.error = Some(("FAVORITE REMOVED".to_string(), Instant::now()));
+            } else {
+                app.favorites.push(dir);
+                app.error = Some(("FAVORITE ADDED".to_string(), Instant::now()));
+            }
+            crate::favorites::save_favorites(&app.favorites);
+        }
+        // Quick jump to favorite (#54)
+        (KeyModifiers::ALT, KeyCode::Char(c)) if c >= '1' && c <= '9' => {
+            let idx = (c as usize) - ('1' as usize);
+            if let Some(dir) = app.favorites.get(idx).cloned() {
+                if dir.is_dir() {
+                    app.navigate_to(dir);
+                } else {
+                    app.error = Some(("FAVORITE PATH NO LONGER EXISTS".to_string(), Instant::now()));
+                }
+            }
+        }
         // Dual-pane diff toggle (#45)
         (KeyModifiers::CONTROL, KeyCode::Char('x')) => {
             if app.dual_pane {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod app;
 mod archive;
 mod config;
+mod favorites;
 mod highlight;
 mod input;
 mod logo;
@@ -74,6 +75,9 @@ fn main() -> io::Result<()> {
 
     // Load bookmarks
     app.marks = marks::load_marks();
+
+    // Load favorites (#54)
+    app.favorites = favorites::load_favorites();
 
     // Setup terminal
     terminal::enable_raw_mode()?;

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -235,6 +235,7 @@ fn collect_hints(app: &App) -> Vec<(&'static str, &'static str)> {
             h.push(("Y", "yank path"));
             h.push(("^L", "ops log"));
             h.push((":", "command"));
+            h.push(("^F", "fav"));
             h.push(("L", "lock"));
             h.push(("t", "theme"));
             h.push(("q", "quit"));

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -147,6 +147,31 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
         }
     }
 
+    // FAVORITES section (#54)
+    if !app.favorites.is_empty() {
+        lines.push(Line::from(Span::raw("")));
+        lines.push(Line::from(Span::styled(
+            " F A V O R I T E S",
+            Style::default().fg(pal.text_dim).bg(pal.bg),
+        )));
+        for (i, fav) in app.favorites.iter().take(9).enumerate() {
+            let dir_name = fav.file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| fav.to_string_lossy().into_owned());
+            let max_fav = width.saturating_sub(7);
+            let display = if dir_name.chars().count() > max_fav {
+                let t: String = dir_name.chars().take(max_fav.saturating_sub(1)).collect();
+                format!("{}\u{2026}", t)
+            } else {
+                dir_name
+            };
+            lines.push(Line::from(vec![
+                Span::styled(format!(" {} ", i + 1), Style::default().fg(pal.text_hot).bg(pal.bg)),
+                Span::styled(display, Style::default().fg(pal.text_mid).bg(pal.bg)),
+            ]));
+        }
+    }
+
     // Pad to fill area
     let height = area.height as usize;
     while lines.len() < height {


### PR DESCRIPTION
## Summary
- New `src/favorites.rs` module for persistence to `~/.config/rem/favorites.toml`
- Ctrl+F toggles current directory as favorite
- Alt+1-9 for quick jump to favorites
- FAVORITES section in sidebar below bookmarks
- `^F fav` hint in footer

## Test plan
- [ ] Press Ctrl+F to pin current directory, verify feedback and sidebar entry
- [ ] Press Alt+1 to jump to first favorite
- [ ] Press Ctrl+F again to unpin, verify removal

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)