### PR TITLE
Add breadcrumb click navigation (#48)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -505,6 +505,8 @@ pub struct CommandState {
 pub struct LayoutAreas {
     pub list_area: Option<(u16, u16, u16, u16)>,     // x, y, w, h
     pub breadcrumb_area: Option<(u16, u16, u16, u16)>,
+    /// Breadcrumb click targets: (start_x, end_x, path) for each visible segment (#48).
+    pub breadcrumb_segments: Vec<(u16, u16, std::path::PathBuf)>,
 }
 
 pub struct PaneState {

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,6 +176,25 @@ fn handle_mouse(app: &mut App, mouse: MouseEvent) {
             app.cursor_down();
         }
         MouseEventKind::Down(MouseButton::Left) => {
+            // Check breadcrumb segment clicks first (#48)
+            let mut nav_target: Option<std::path::PathBuf> = None;
+            if let Some((_, by, _, bh)) = app.layout_areas.breadcrumb_area {
+                if mouse.row >= by && mouse.row < by + bh {
+                    for (start_x, end_x, path) in &app.layout_areas.breadcrumb_segments {
+                        if mouse.column >= *start_x && mouse.column < *end_x {
+                            nav_target = Some(path.clone());
+                            break;
+                        }
+                    }
+                }
+            }
+            if let Some(path) = nav_target {
+                if path.is_dir() {
+                    app.navigate_to(path);
+                }
+                return;
+            }
+
             // Click to select in file list area
             if let Some((lx, ly, _lw, lh)) = app.layout_areas.list_area {
                 let mx = mouse.column;

--- a/src/ui/breadcrumb.rs
+++ b/src/ui/breadcrumb.rs
@@ -6,11 +6,11 @@ use ratatui::widgets::{Block, BorderType, Borders, Paragraph};
 
 use crate::app::App;
 
-pub fn render(f: &mut Frame, app: &App, area: Rect) {
+pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
     render_pane(f, app, app.active_pane, area, true);
 }
 
-pub fn render_pane(f: &mut Frame, app: &App, pane_idx: usize, area: Rect, show_cursor: bool) {
+pub fn render_pane(f: &mut Frame, app: &mut App, pane_idx: usize, area: Rect, show_cursor: bool) {
     let pal = app.palette;
 
     // Archive mode: show archive path with internal directory (#19)
@@ -35,6 +35,12 @@ pub fn render_pane(f: &mut Frame, app: &App, pane_idx: usize, area: Rect, show_c
     let max_width = area.width as usize - 4; // reserve space for cursor
     let mut built = String::new();
 
+    // Track which segments survive left-truncation for click targets (#48).
+    // When truncation happens we reset, so we record the index of the first
+    // segment that is actually rendered after the last truncation.
+    let mut first_visible_seg: usize = 0;
+    let mut truncated = false;
+
     for (i, seg) in segments.iter().enumerate() {
         let is_last = i == segments.len() - 1;
         let sep = " / ";
@@ -49,6 +55,8 @@ pub fn render_pane(f: &mut Frame, app: &App, pane_idx: usize, area: Rect, show_c
             spans = vec![Span::styled(" ", Style::default())];
             spans.push(Span::styled("\u{2026} / ", Style::default().fg(pal.text_dim)));
             built.clear();
+            first_visible_seg = i;
+            truncated = true;
         }
 
         if !built.is_empty() {
@@ -76,6 +84,46 @@ pub fn render_pane(f: &mut Frame, app: &App, pane_idx: usize, area: Rect, show_c
         format!(" SORT:{}", app.sort_mode.label()),
         Style::default().fg(pal.text_dim),
     ));
+
+    // Record breadcrumb click targets (#48).
+    // Only for the active pane (show_cursor == true) and non-archive mode.
+    if show_cursor && app.archive.is_none() {
+        app.layout_areas.breadcrumb_segments.clear();
+        app.layout_areas.breadcrumb_area = Some((area.x, area.y, area.width, area.height));
+
+        let full_path = &app.panes[pane_idx].current_dir;
+        let components: Vec<_> = full_path.components().collect();
+
+        // Walk the visible segments and compute x positions.
+        // The leading span is " " (1 char).  If truncated, we have " " + "... / " (1 + 5 = 6 chars prefix).
+        let mut x_offset: u16 = area.x;
+        if truncated {
+            x_offset += 1 + 5; // " " + "... / " (ellipsis is 1 char + " / " = 4, total 5)
+        } else {
+            x_offset += 1; // leading space
+        }
+
+        for (vi, seg_idx) in (first_visible_seg..segments.len()).enumerate() {
+            if vi > 0 {
+                x_offset += 3; // " / "
+            }
+            let seg_text = segments[seg_idx].to_uppercase();
+            let seg_width = seg_text.len() as u16;
+            let start_x = x_offset;
+            let end_x = x_offset + seg_width;
+
+            // Build cumulative path up to this segment using OS path components.
+            if seg_idx < components.len() {
+                let mut nav_path = std::path::PathBuf::new();
+                for c in components.iter().take(seg_idx + 1) {
+                    nav_path.push(c);
+                }
+                app.layout_areas.breadcrumb_segments.push((start_x, end_x, nav_path));
+            }
+
+            x_offset = end_x;
+        }
+    }
 
     // Use pulsed border color for active pane (#18)
     let border_color = if show_cursor { app.pulsed_border() } else { pal.border_dim };

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -189,8 +189,9 @@ fn render_dual(f: &mut Frame, app: &mut App, area: ratatui::layout::Rect) {
         ])
         .split(outer[1]);
 
-    breadcrumb::render_pane(f, app, 0, breadcrumb_halves[0], app.active_pane == 0);
-    breadcrumb::render_pane(f, app, 1, breadcrumb_halves[1], app.active_pane == 1);
+    let active = app.active_pane;
+    breadcrumb::render_pane(f, app, 0, breadcrumb_halves[0], active == 0);
+    breadcrumb::render_pane(f, app, 1, breadcrumb_halves[1], active == 1);
 
     // Editor takes over full body in dual-pane mode too
     if app.mode == crate::app::Mode::Edit {


### PR DESCRIPTION
## Summary
- Store breadcrumb segment x-positions and cumulative paths during render
- Detect mouse clicks on breadcrumb segments to navigate to that directory
- Works with left-truncated paths

## Test plan
- [ ] Click on a parent segment in the breadcrumb bar
- [ ] Verify navigation to that directory
- [ ] Verify deep paths with truncation still work

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)