### PR TITLE
Add tab completion and history in command mode (#49)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -491,6 +491,10 @@ pub struct CommandState {
     pub cursor: usize,
     pub history: Vec<String>,
     pub history_idx: Option<usize>,
+    /// Tab-completion candidates (#49).
+    pub completions: Vec<String>,
+    pub completion_idx: Option<usize>,
+    pub completion_prefix: String,
 }
 
 /// Layout hit-test areas for mouse support (#38).
@@ -771,6 +775,9 @@ impl App {
                 cursor: 0,
                 history: Vec::new(),
                 history_idx: None,
+                completions: Vec::new(),
+                completion_idx: None,
+                completion_prefix: String::new(),
             },
         };
         app.load_entries();

--- a/src/input.rs
+++ b/src/input.rs
@@ -1208,6 +1208,8 @@ fn handle_command(app: &mut App, key: KeyEvent) {
                     .unwrap_or(app.command_state.input.len());
                 app.command_state.input.drain(byte_idx..next_byte);
             }
+            app.command_state.completions.clear();
+            app.command_state.completion_idx = None;
         }
         (_, KeyCode::Left) => {
             if app.command_state.cursor > 0 {
@@ -1218,6 +1220,65 @@ fn handle_command(app: &mut App, key: KeyEvent) {
             let len = app.command_state.input.chars().count();
             if app.command_state.cursor < len {
                 app.command_state.cursor += 1;
+            }
+        }
+        // Tab completion (#49)
+        (_, KeyCode::Tab) => {
+            if app.command_state.completions.is_empty()
+                || app.command_state.completion_prefix != app.command_state.input
+            {
+                // Generate completions
+                app.command_state.completion_prefix = app.command_state.input.clone();
+                app.command_state.completions.clear();
+                app.command_state.completion_idx = None;
+
+                let input = &app.command_state.input;
+                if input.starts_with("cd ") {
+                    // Path completion
+                    let partial = &input[3..];
+                    let (dir, prefix) = if let Some(pos) = partial.rfind('/').or_else(|| partial.rfind('\\')) {
+                        let base = &partial[..=pos];
+                        let pfx = &partial[pos + 1..];
+                        (app.pane().current_dir.join(base), pfx.to_string())
+                    } else {
+                        (app.pane().current_dir.clone(), partial.to_string())
+                    };
+                    if let Ok(rd) = std::fs::read_dir(&dir) {
+                        for entry in rd.flatten() {
+                            let name = entry.file_name().to_string_lossy().into_owned();
+                            if name.to_lowercase().starts_with(&prefix.to_lowercase()) {
+                                let is_dir = entry.file_type().map_or(false, |t| t.is_dir());
+                                let suffix = if is_dir { "/" } else { "" };
+                                let base_path = if let Some(pos) = partial.rfind('/').or_else(|| partial.rfind('\\')) {
+                                    format!("{}{}{}", &partial[..=pos], name, suffix)
+                                } else {
+                                    format!("{}{}", name, suffix)
+                                };
+                                app.command_state.completions.push(format!("cd {}", base_path));
+                            }
+                        }
+                    }
+                } else {
+                    // Command name completion
+                    let commands = [
+                        "q", "quit", "cd", "set", "sort", "theme", "symbols", "help",
+                    ];
+                    for cmd in &commands {
+                        if cmd.starts_with(input.as_str()) {
+                            app.command_state.completions.push(cmd.to_string());
+                        }
+                    }
+                }
+            }
+            // Cycle through completions
+            if !app.command_state.completions.is_empty() {
+                let idx = match app.command_state.completion_idx {
+                    Some(i) => (i + 1) % app.command_state.completions.len(),
+                    None => 0,
+                };
+                app.command_state.completion_idx = Some(idx);
+                app.command_state.input = app.command_state.completions[idx].clone();
+                app.command_state.cursor = app.command_state.input.chars().count();
             }
         }
         (_, KeyCode::Up) => {
@@ -1252,6 +1313,8 @@ fn handle_command(app: &mut App, key: KeyEvent) {
         (KeyModifiers::CONTROL, KeyCode::Char('u')) => {
             app.command_state.input.clear();
             app.command_state.cursor = 0;
+            app.command_state.completions.clear();
+            app.command_state.completion_idx = None;
         }
         (KeyModifiers::NONE | KeyModifiers::SHIFT, KeyCode::Char(c)) => {
             let byte_idx = app.command_state.input.char_indices()
@@ -1260,6 +1323,8 @@ fn handle_command(app: &mut App, key: KeyEvent) {
                 .unwrap_or(app.command_state.input.len());
             app.command_state.input.insert(byte_idx, c);
             app.command_state.cursor += 1;
+            app.command_state.completions.clear();
+            app.command_state.completion_idx = None;
         }
         _ => {}
     }

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -87,11 +87,24 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
     // Command mode (#41)
     if matches!(app.mode, Mode::Command) {
         let cursor_char = if app.blink_on { app.symbols.text_cursor } else { " " };
-        let cmd_line = Line::from(vec![
+        let mut cmd_spans = vec![
             Span::styled(" MOTHER> ", Style::default().fg(pal.text_hot).bg(pal.surface)),
             Span::styled(app.command_state.input.clone(), Style::default().fg(pal.text_mid).bg(pal.surface)),
-            Span::styled(cursor_char, Style::default().fg(pal.text_hot).bg(pal.surface)),
-        ]);
+        ];
+        // Completion hint (#49)
+        if let Some(idx) = app.command_state.completion_idx {
+            if let Some(completion) = app.command_state.completions.get(idx) {
+                if completion.len() > app.command_state.input.len() {
+                    let hint = &completion[app.command_state.input.len()..];
+                    cmd_spans.push(Span::styled(
+                        hint.to_string(),
+                        Style::default().fg(pal.text_dim).bg(pal.surface),
+                    ));
+                }
+            }
+        }
+        cmd_spans.push(Span::styled(cursor_char, Style::default().fg(pal.text_hot).bg(pal.surface)));
+        let cmd_line = Line::from(cmd_spans);
         let block = Block::default()
             .borders(Borders::TOP)
             .border_type(BorderType::Plain)


### PR DESCRIPTION
## Summary
- Tab completes command names (q, quit, cd, set, sort, theme, symbols, help)
- Tab after `cd ` completes filesystem paths
- Up/Down arrows cycle through command history
- Dim completion hint shown inline after cursor

## Test plan
- [ ] Type `:s` then Tab, verify `sort` completes
- [ ] Type `:cd ` then partial dir name and Tab, verify path completion
- [ ] Execute commands, then press Up to recall from history

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)