### PR TITLE
Add shell command execution from command mode (#57)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -697,6 +697,8 @@ pub struct App {
     pub command_state: CommandState,
     // Favorites / pinned directories (#54)
     pub favorites: Vec<PathBuf>,
+    // Shell command output (#57)
+    pub shell_output: Option<String>,
 }
 
 impl App {
@@ -786,6 +788,7 @@ impl App {
                 completion_prefix: String::new(),
             },
             favorites: Vec::new(),
+            shell_output: None,
         };
         app.load_entries();
         app.git_info = GitInfo::detect(&app.panes[0].current_dir);

--- a/src/input.rs
+++ b/src/input.rs
@@ -1358,7 +1358,60 @@ fn handle_command(app: &mut App, key: KeyEvent) {
 }
 
 fn execute_command(app: &mut App, cmd: &str) {
-    let parts: Vec<&str> = cmd.trim().splitn(2, ' ').collect();
+    let trimmed = cmd.trim();
+
+    // Shell command: !<command>
+    if let Some(shell_cmd) = trimmed.strip_prefix('!') {
+        let shell_cmd = shell_cmd.trim();
+        if shell_cmd.is_empty() {
+            app.error = Some(("SHELL COMMAND REQUIRED AFTER !".to_string(), Instant::now()));
+            return;
+        }
+        app.shell_output = None;
+        let output = if cfg!(windows) {
+            std::process::Command::new("cmd")
+                .args(["/C", shell_cmd])
+                .current_dir(&app.pane().current_dir)
+                .output()
+        } else {
+            std::process::Command::new("sh")
+                .args(["-c", shell_cmd])
+                .current_dir(&app.pane().current_dir)
+                .output()
+        };
+        match output {
+            Ok(out) => {
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                let combined = if stderr.is_empty() {
+                    stdout.to_string()
+                } else if stdout.is_empty() {
+                    stderr.to_string()
+                } else {
+                    format!("{}\n{}", stdout, stderr)
+                };
+                let truncated = if combined.len() > 200 {
+                    format!("{}…", &combined[..200])
+                } else {
+                    combined
+                };
+                let msg = truncated.lines().next().unwrap_or("").to_string();
+                app.error = Some((
+                    if msg.is_empty() { "COMMAND EXECUTED".to_string() } else { msg },
+                    Instant::now(),
+                ));
+                app.shell_output = Some(truncated);
+                app.ops_log.push("SHELL", shell_cmd);
+            }
+            Err(e) => {
+                app.error = Some((format!("SHELL FAILURE: {}", e), Instant::now()));
+            }
+        }
+        app.load_entries();
+        return;
+    }
+
+    let parts: Vec<&str> = trimmed.splitn(2, ' ').collect();
     match parts.first().copied() {
         Some("q") | Some("quit") => {
             app.should_quit = true;
@@ -1423,8 +1476,11 @@ fn execute_command(app: &mut App, cmd: &str) {
                 crate::config::save_symbols(variant);
             }
         }
+        Some("shell") => {
+            app.error = Some(("USE :!<command> TO EXECUTE SHELL COMMANDS".to_string(), Instant::now()));
+        }
         Some("help") => {
-            app.error = Some(("COMMANDS: q cd set sort theme symbols help".to_string(), Instant::now()));
+            app.error = Some(("COMMANDS: q cd set sort theme symbols shell help".to_string(), Instant::now()));
         }
         _ => {
             app.error = Some(("UNKNOWN COMMAND \u{2014} TYPE :help".to_string(), Instant::now()));


### PR DESCRIPTION
## Summary
- Add `:!<command>` syntax to execute shell commands from command mode
- Captures stdout/stderr, shows first line as feedback
- Platform-aware: cmd /C on Windows, sh -c on Unix
- Logs to ops_log, refreshes directory listing after execution
- Added `:shell` alias with usage hint

## Test plan
- [ ] Type `:!ls` (or `:!dir` on Windows), verify output shown as feedback
- [ ] Verify directory refreshes after command execution
- [ ] Verify `:shell` shows usage hint

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)