### PR TITLE
Add file tagging system with persistent labels (#58)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -47,6 +47,7 @@ pub enum Mode {
     Edit,                 // in-app text editor
     OpsLog,               // operations log viewer (#43)
     Command,              // MU-TH-UR command mode (#41)
+    TagInput,             // typing a tag name (#58)
 }
 
 #[derive(PartialEq, Eq, Clone)]
@@ -709,6 +710,9 @@ pub struct App {
     pub shell_output: Option<String>,
     // Undo stack (#53)
     pub undo_stack: Vec<UndoRecord>,
+    // File tagging (#58)
+    pub tags: crate::tags::TagStore,
+    pub tag_input: String,
 }
 
 impl App {
@@ -800,6 +804,8 @@ impl App {
             favorites: Vec::new(),
             shell_output: None,
             undo_stack: Vec::new(),
+            tags: crate::tags::TagStore::new(),
+            tag_input: String::new(),
         };
         app.load_entries();
         app.git_info = GitInfo::detect(&app.panes[0].current_dir);

--- a/src/input.rs
+++ b/src/input.rs
@@ -43,6 +43,7 @@ pub fn handle_key(app: &mut App, key: KeyEvent) {
         Mode::Edit => handle_edit(app, key),
         Mode::OpsLog => handle_ops_log(app, key),
         Mode::Command => handle_command(app, key),
+        Mode::TagInput => handle_tag_input(app, key),
     }
 }
 
@@ -324,6 +325,13 @@ fn handle_normal(app: &mut App, key: KeyEvent) {
             app.command_state.cursor = 0;
             app.command_state.history_idx = None;
             app.mode = Mode::Command;
+        }
+        // File tagging (#58)
+        (KeyModifiers::CONTROL, KeyCode::Char('t')) => {
+            if app.current_entry().is_some() {
+                app.tag_input.clear();
+                app.mode = Mode::TagInput;
+            }
         }
         // Tree view toggle (#44)
         (KeyModifiers::SHIFT, KeyCode::Char('T')) => {
@@ -1483,12 +1491,68 @@ fn execute_command(app: &mut App, cmd: &str) {
         Some("shell") => {
             app.error = Some(("USE :!<command> TO EXECUTE SHELL COMMANDS".to_string(), Instant::now()));
         }
+        Some("tag") => {
+            if let Some(tag) = parts.get(1).map(|s| s.trim().to_string()) {
+                if !tag.is_empty() {
+                    if let Some(entry) = app.current_entry() {
+                        let path = entry.path.clone();
+                        app.tags.add_tag(path, tag);
+                        crate::tags::save_tags(&app.tags);
+                        app.error = Some(("TAG ADDED".to_string(), Instant::now()));
+                    }
+                }
+            } else {
+                app.error = Some(("USAGE: tag <name>".to_string(), Instant::now()));
+            }
+        }
+        Some("untag") => {
+            if let Some(tag) = parts.get(1).map(|s| s.trim()) {
+                if !tag.is_empty() {
+                    if let Some(entry) = app.current_entry() {
+                        let path = entry.path.clone();
+                        app.tags.remove_tag(&path, tag);
+                        crate::tags::save_tags(&app.tags);
+                        app.error = Some(("TAG REMOVED".to_string(), Instant::now()));
+                    }
+                }
+            } else {
+                app.error = Some(("USAGE: untag <name>".to_string(), Instant::now()));
+            }
+        }
         Some("help") => {
-            app.error = Some(("COMMANDS: q cd set sort theme symbols shell help".to_string(), Instant::now()));
+            app.error = Some(("COMMANDS: q cd set sort theme symbols shell tag untag help".to_string(), Instant::now()));
         }
         _ => {
             app.error = Some(("UNKNOWN COMMAND \u{2014} TYPE :help".to_string(), Instant::now()));
         }
+    }
+}
+
+/// Handle tag input mode (#58).
+fn handle_tag_input(app: &mut App, key: KeyEvent) {
+    match (key.modifiers, key.code) {
+        (_, KeyCode::Esc) => {
+            app.mode = Mode::Normal;
+        }
+        (_, KeyCode::Enter) => {
+            if !app.tag_input.is_empty() {
+                if let Some(entry) = app.current_entry() {
+                    let path = entry.path.clone();
+                    let tag = app.tag_input.clone();
+                    app.tags.add_tag(path, tag);
+                    crate::tags::save_tags(&app.tags);
+                    app.error = Some(("TAG ADDED".to_string(), Instant::now()));
+                }
+            }
+            app.mode = Mode::Normal;
+        }
+        (_, KeyCode::Backspace) => {
+            app.tag_input.pop();
+        }
+        (KeyModifiers::NONE | KeyModifiers::SHIFT, KeyCode::Char(c)) => {
+            app.tag_input.push(c);
+        }
+        _ => {}
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod palette;
 mod preview;
 mod symbols;
 mod sysmon;
+mod tags;
 mod throbber;
 mod ui;
 
@@ -79,6 +80,9 @@ fn main() -> io::Result<()> {
     // Load favorites (#54)
     app.favorites = favorites::load_favorites();
 
+    // Load tags (#58)
+    app.tags = tags::load_tags();
+
     // Setup terminal
     terminal::enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -107,6 +111,9 @@ fn main() -> io::Result<()> {
 
     // Save bookmarks
     marks::save_marks(&app.marks);
+
+    // Save tags (#58)
+    tags::save_tags(&app.tags);
 
     match result {
         Ok(Some(path)) => {

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -1,0 +1,73 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Default)]
+struct TagsFile {
+    #[serde(default)]
+    tags: HashMap<String, Vec<String>>,
+}
+
+pub struct TagStore {
+    pub tags: HashMap<PathBuf, Vec<String>>,
+}
+
+impl TagStore {
+    pub fn new() -> Self {
+        Self { tags: HashMap::new() }
+    }
+
+    pub fn get(&self, path: &Path) -> Option<&Vec<String>> {
+        self.tags.get(path)
+    }
+
+    pub fn add_tag(&mut self, path: PathBuf, tag: String) {
+        let entry = self.tags.entry(path).or_insert_with(Vec::new);
+        if !entry.contains(&tag) {
+            entry.push(tag);
+        }
+    }
+
+    pub fn remove_tag(&mut self, path: &Path, tag: &str) {
+        if let Some(tags) = self.tags.get_mut(path) {
+            tags.retain(|t| t != tag);
+            if tags.is_empty() {
+                self.tags.remove(path);
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn has_tags(&self, path: &Path) -> bool {
+        self.tags.get(path).map_or(false, |t| !t.is_empty())
+    }
+}
+
+fn tags_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("rem").join("tags.toml"))
+}
+
+pub fn load_tags() -> TagStore {
+    let Some(path) = tags_path() else { return TagStore::new() };
+    let Ok(content) = std::fs::read_to_string(&path) else { return TagStore::new() };
+    let Ok(file) = toml::from_str::<TagsFile>(&content) else { return TagStore::new() };
+    let tags = file.tags.into_iter()
+        .map(|(k, v)| (PathBuf::from(k), v))
+        .collect();
+    TagStore { tags }
+}
+
+pub fn save_tags(store: &TagStore) {
+    let Some(path) = tags_path() else { return };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let file = TagsFile {
+        tags: store.tags.iter()
+            .map(|(k, v)| (k.to_string_lossy().into_owned(), v.clone()))
+            .collect(),
+    };
+    if let Ok(content) = toml::to_string_pretty(&file) {
+        let _ = std::fs::write(&path, content);
+    }
+}

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -14,6 +14,9 @@ pub fn required_height(app: &App, width: u16) -> u16 {
     if matches!(app.mode, Mode::Command) {
         return 1;
     }
+    if matches!(app.mode, Mode::TagInput) {
+        return 1;
+    }
     let mut h = 0u16;
     // Disk warning row (#34)
     if app.disk_warning.is_some() {
@@ -111,6 +114,24 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
             .border_style(Style::default().fg(pal.border_hot))
             .style(Style::default().bg(pal.surface));
         let paragraph = Paragraph::new(cmd_line).block(block);
+        f.render_widget(paragraph, area);
+        return;
+    }
+
+    // Tag input mode (#58)
+    if matches!(app.mode, Mode::TagInput) {
+        let cursor_char = if app.blink_on { app.symbols.text_cursor } else { " " };
+        let tag_line = Line::from(vec![
+            Span::styled(" TAG> ", Style::default().fg(pal.text_hot).bg(pal.surface)),
+            Span::styled(app.tag_input.clone(), Style::default().fg(pal.text_mid).bg(pal.surface)),
+            Span::styled(cursor_char, Style::default().fg(pal.text_hot).bg(pal.surface)),
+        ]);
+        let block = Block::default()
+            .borders(Borders::TOP)
+            .border_type(BorderType::Plain)
+            .border_style(Style::default().fg(pal.border_hot))
+            .style(Style::default().bg(pal.surface));
+        let paragraph = Paragraph::new(tag_line).block(block);
         f.render_widget(paragraph, area);
         return;
     }
@@ -250,6 +271,7 @@ fn collect_hints(app: &App) -> Vec<(&'static str, &'static str)> {
             if !app.undo_stack.is_empty() {
                 h.push(("^Z", "undo"));
             }
+            h.push(("^T", "tag"));
             h.push((":", "command"));
             h.push(("^F", "fav"));
             h.push(("L", "lock"));
@@ -329,6 +351,13 @@ fn collect_hints(app: &App) -> Vec<(&'static str, &'static str)> {
                 ("j/k", "scroll"),
                 ("g/G", "top/bottom"),
                 ("esc", "close"),
+            ]
+        }
+        Mode::TagInput => {
+            vec![
+                ("type", "tag name"),
+                ("enter", "add"),
+                ("esc", "cancel"),
             ]
         }
         Mode::Command => {

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -44,6 +44,7 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
         Mode::Edit => ("EDIT", pal.text_mid),
         Mode::OpsLog => ("LOG", pal.text_mid),
         Mode::Command => ("COMMAND", pal.text_mid),
+        Mode::TagInput => ("TAG", pal.text_mid),
     };
 
     // Left side: status info

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -315,6 +315,16 @@ pub fn render_pane(f: &mut Frame, app: &App, pane_idx: usize, area: Rect) {
             }
         }
 
+        // Tag badges (#58)
+        if let Some(tags) = app.tags.get(&entry.path) {
+            for tag in tags.iter().take(3) {
+                spans.push(Span::styled(
+                    format!(" [{}]", tag.to_uppercase()),
+                    Style::default().fg(pal.border_mid).bg(row_bg),
+                ));
+            }
+        }
+
         // Type badge
         if show_type {
             let badge = file_type_badge(entry);

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -165,6 +165,19 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
         )));
     }
 
+    // Tags (#58)
+    if let Some(entry) = app.current_entry() {
+        if let Some(tags) = app.tags.get(&entry.path) {
+            lines.push(Line::from(vec![
+                Span::styled(" TAGS  ", Style::default().fg(pal.text_dim).bg(pal.bg)),
+                Span::styled(
+                    tags.join(", "),
+                    Style::default().fg(pal.text_hot).bg(pal.bg),
+                ),
+            ]));
+        }
+    }
+
     // SHA-256 hash display (#20)
     if let Some(entry) = app.current_entry() {
         if let Some((hash_path, hash_val)) = &app.last_hash {


### PR DESCRIPTION
## Summary
- New `src/tags.rs` module with TagStore persisted to `~/.config/rem/tags.toml`
- Ctrl+T opens tag input mode to add tags to files
- `:tag <name>` and `:untag <name>` commands in command mode
- Tag badges shown in file list (up to 3 per entry) in `border_mid` color
- Tags displayed in sidebar for selected entry
- TagInput mode with dedicated footer hints

## Test plan
- [ ] Press Ctrl+T, type a tag name, Enter — verify tag added
- [ ] Verify tag badge appears in file list
- [ ] Verify tags shown in sidebar for tagged file
- [ ] Use `:untag <name>` to remove tag
- [ ] Verify tags persist across restarts

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)