### PR TITLE
Add COMMS INTERCEPT idle radio chatter (#74)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -713,6 +713,8 @@ pub struct App {
     // File tagging (#58)
     pub tags: crate::tags::TagStore,
     pub tag_input: String,
+    // Comms intercept (#74)
+    pub comms: crate::comms::CommsState,
 }
 
 impl App {
@@ -806,6 +808,7 @@ impl App {
             undo_stack: Vec::new(),
             tags: crate::tags::TagStore::new(),
             tag_input: String::new(),
+            comms: crate::comms::CommsState::new(),
         };
         app.load_entries();
         app.git_info = GitInfo::detect(&app.panes[0].current_dir);
@@ -967,6 +970,9 @@ impl App {
         if !self.idle_locked {
             self.idle_active = now.duration_since(self.last_input).as_secs() >= 45;
         }
+        // Comms intercept (#74)
+        let idle_secs = now.duration_since(self.last_input).as_secs();
+        self.comms.tick(idle_secs);
         // CRT glitch (#15)
         self.glitch_tick = self.glitch_tick.wrapping_add(1);
         // Green phosphor trail: track cursor movement, decay ghosts

--- a/src/comms.rs
+++ b/src/comms.rs
@@ -1,0 +1,63 @@
+use std::time::Instant;
+
+const MESSAGES: &[&str] = &[
+    "LV-426 BEACON DETECTED",
+    "COMPANY DIRECTIVE 937 UPDATED",
+    "CREW EXPENDABLE — PRIORITY OVERRIDE",
+    "HYPERDRIVE COOLANT AT 47%",
+    "GATEWAY STATION RELAY NOMINAL",
+    "SPECIAL ORDER 937 — SCIENCE OFFICER EYES ONLY",
+    "BIOSCAN ANOMALY — SECTOR 7G",
+    "CORPORATE QUARTERLY REVIEW — ALL TERMINALS",
+    "TOWING VESSEL NOSTROMO — REROUTING",
+    "WEYLAND-YUTANI MEMO: PRODUCT RECALL XM-310",
+    "DEEP SPACE RELAY — SIGNAL DEGRADED",
+    "ATMOSPHERIC PROCESSOR — PRESSURE NOMINAL",
+    "COLONY STATUS: LV-426 — NO RESPONSE",
+    "SHUTTLE NARCISSUS — BEACON ACTIVE",
+    "FLIGHT RECORDER RECOVERED — ANALYSIS PENDING",
+    "CLASSIFIED: XENOMORPH SPECIMEN REQUEST",
+    "MU-TH-UR UPLINK — HANDSHAKE COMPLETE",
+    "TERRAFORMING PERMIT 2039-B APPROVED",
+    "CRYO DECK MALFUNCTION — NON-CRITICAL",
+    "SUPPLY DROP COORDINATES RECEIVED",
+];
+
+pub struct CommsState {
+    shown: Vec<usize>,
+    pub current: Option<(String, Instant)>,
+    last_comms: Instant,
+    rng_counter: u32,
+}
+
+impl CommsState {
+    pub fn new() -> Self {
+        Self { shown: Vec::new(), current: None, last_comms: Instant::now(), rng_counter: 0 }
+    }
+    pub fn tick(&mut self, idle_secs: u64) {
+        if idle_secs < 20 || idle_secs >= 45 {
+            self.current = None;
+            return;
+        }
+        if let Some((_, ts)) = &self.current {
+            if ts.elapsed().as_secs() >= 3 { self.current = None; }
+        }
+        if self.current.is_none() && self.last_comms.elapsed().as_secs() >= 8 {
+            self.last_comms = Instant::now();
+            self.pick_message();
+        }
+    }
+    fn pick_message(&mut self) {
+        if self.shown.len() >= MESSAGES.len() { self.shown.clear(); }
+        let available: Vec<usize> = (0..MESSAGES.len()).filter(|i| !self.shown.contains(i)).collect();
+        if available.is_empty() { return; }
+        self.rng_counter = self.rng_counter.wrapping_mul(1103515245).wrapping_add(12345);
+        let idx = available[(self.rng_counter as usize) % available.len()];
+        self.shown.push(idx);
+        self.current = Some((MESSAGES[idx].to_string(), Instant::now()));
+    }
+    pub fn dismiss(&mut self) {
+        self.current = None;
+        self.last_comms = Instant::now();
+    }
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -12,6 +12,9 @@ pub fn handle_key(app: &mut App, key: KeyEvent) {
         app.anim_frame = 0;
     }
 
+    // Dismiss comms on input (#74)
+    app.comms.dismiss();
+
     // Dismiss error on any key
     if app.error.is_some() {
         app.error = None;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod app;
 mod archive;
+mod comms;
 mod config;
 mod favorites;
 mod highlight;

--- a/src/ui/statusbar.rs
+++ b/src/ui/statusbar.rs
@@ -9,6 +9,7 @@ use crate::app::App;
 pub fn should_show(app: &App) -> bool {
     app.bg_operation.is_some() || app.op_feedback.is_some()
         || app.hash_op.is_some() || app.disk_scan.is_some()
+        || app.comms.current.is_some()
 }
 
 pub fn render(f: &mut Frame, app: &App, area: Rect) {
@@ -170,6 +171,22 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
             Span::styled(
                 format!(" {}", fb.label),
                 Style::default().fg(color).bg(pal.surface),
+            ),
+        ]
+    } else if let Some((msg, _)) = &app.comms.current {
+        let throbber_char = app.heartbeat.frame();
+        vec![
+            Span::styled(
+                format!(" {} ", throbber_char),
+                Style::default().fg(pal.text_hot).bg(pal.surface),
+            ),
+            Span::styled(
+                "[COMMS INTERCEPT]",
+                Style::default().fg(pal.text_mid).bg(pal.surface),
+            ),
+            Span::styled(
+                format!("  {}", msg),
+                Style::default().fg(pal.text_dim).bg(pal.surface),
             ),
         ]
     } else {


### PR DESCRIPTION
## Summary
- Adds ambient Weyland-Yutani lore messages in status bar after 20-45s idle
- 20 themed messages with LCG random selection, 3s display / 8s cooldown
- Dismisses on any keypress

## Test plan
- [ ] Build and run `cargo run`
- [ ] Wait 20+ seconds idle, verify COMMS message appears in status bar
- [ ] Press any key, verify message dismisses
- [ ] Verify messages cycle with cooldown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>