### PR TITLE
Add git staging integration (#82)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -713,6 +713,8 @@ pub struct App {
     // File tagging (#58)
     pub tags: crate::tags::TagStore,
     pub tag_input: String,
+    // Git file statuses (#82)
+    pub git_file_statuses: std::collections::HashMap<String, crate::gitstatus::GitFileStatus>,
 }
 
 impl App {
@@ -806,6 +808,7 @@ impl App {
             undo_stack: Vec::new(),
             tags: crate::tags::TagStore::new(),
             tag_input: String::new(),
+            git_file_statuses: std::collections::HashMap::new(),
         };
         app.load_entries();
         app.git_info = GitInfo::detect(&app.panes[0].current_dir);

--- a/src/gitstatus.rs
+++ b/src/gitstatus.rs
@@ -1,0 +1,79 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GitFileStatus {
+    Added,
+    Modified,
+    Untracked,
+    Staged,
+    Conflict,
+}
+
+pub fn parse_git_status(dir: &Path) -> HashMap<String, GitFileStatus> {
+    let output = std::process::Command::new("git")
+        .args(["status", "--porcelain", "-uall"])
+        .current_dir(dir)
+        .output();
+    let Ok(output) = output else { return HashMap::new() };
+    if !output.status.success() { return HashMap::new(); }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut statuses = HashMap::new();
+
+    for line in stdout.lines() {
+        if line.len() < 4 { continue; }
+        let index = line.as_bytes()[0];
+        let worktree = line.as_bytes()[1];
+        let filename = line[3..].trim().to_string();
+        // Strip path to just filename
+        let name = Path::new(&filename)
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or(filename.clone());
+
+        let status = match (index, worktree) {
+            (b'U', _) | (_, b'U') | (b'A', b'A') | (b'D', b'D') => GitFileStatus::Conflict,
+            (b'A', _) | (b'C', _) => GitFileStatus::Added,
+            (b'M', b' ') | (b'R', _) | (b'D', _) => GitFileStatus::Staged,
+            (_, b'M') | (b' ', b'D') => GitFileStatus::Modified,
+            (b'?', b'?') => GitFileStatus::Untracked,
+            _ => continue,
+        };
+        statuses.insert(name, status);
+    }
+    statuses
+}
+
+pub fn git_stage(dir: &Path, file: &str) -> Result<(), String> {
+    let output = std::process::Command::new("git")
+        .args(["add", file])
+        .current_dir(dir)
+        .output()
+        .map_err(|e| format!("GIT ADD FAILED: {}", e))?;
+    if output.status.success() { Ok(()) }
+    else { Err(format!("GIT ADD: {}", String::from_utf8_lossy(&output.stderr))) }
+}
+
+pub fn git_unstage(dir: &Path, file: &str) -> Result<(), String> {
+    let output = std::process::Command::new("git")
+        .args(["reset", "HEAD", file])
+        .current_dir(dir)
+        .output()
+        .map_err(|e| format!("GIT RESET FAILED: {}", e))?;
+    if output.status.success() { Ok(()) }
+    else { Err(format!("GIT RESET: {}", String::from_utf8_lossy(&output.stderr))) }
+}
+
+pub fn git_commit(dir: &Path, msg: &str) -> Result<String, String> {
+    let output = std::process::Command::new("git")
+        .args(["commit", "-m", msg])
+        .current_dir(dir)
+        .output()
+        .map_err(|e| format!("GIT COMMIT FAILED: {}", e))?;
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        Err(format!("GIT COMMIT: {}", String::from_utf8_lossy(&output.stderr)))
+    }
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -363,6 +363,34 @@ fn handle_normal(app: &mut App, key: KeyEvent) {
                 }
             }
         }
+        // Git stage/unstage (#82)
+        (KeyModifiers::CONTROL, KeyCode::Char('g')) => {
+            if let Some(entry) = app.current_entry() {
+                let name = entry.name.clone();
+                let dir = app.pane().current_dir.clone();
+                if let Some(status) = app.git_file_statuses.get(&name) {
+                    let result = match status {
+                        crate::gitstatus::GitFileStatus::Staged => crate::gitstatus::git_unstage(&dir, &name),
+                        _ => crate::gitstatus::git_stage(&dir, &name),
+                    };
+                    match result {
+                        Ok(()) => {
+                            app.git_file_statuses = crate::gitstatus::parse_git_status(&dir);
+                            app.error = Some(("GIT STATUS UPDATED".to_string(), Instant::now()));
+                        }
+                        Err(e) => app.error = Some((e, Instant::now())),
+                    }
+                } else {
+                    match crate::gitstatus::git_stage(&dir, &name) {
+                        Ok(()) => {
+                            app.git_file_statuses = crate::gitstatus::parse_git_status(&dir);
+                            app.error = Some(("STAGED".to_string(), Instant::now()));
+                        }
+                        Err(e) => app.error = Some((e, Instant::now())),
+                    }
+                }
+            }
+        }
         // Dual-pane diff toggle (#45)
         (KeyModifiers::CONTROL, KeyCode::Char('x')) => {
             if app.dual_pane {
@@ -1300,7 +1328,7 @@ fn handle_command(app: &mut App, key: KeyEvent) {
                 } else {
                     // Command name completion
                     let commands = [
-                        "q", "quit", "cd", "set", "sort", "theme", "symbols", "help",
+                        "q", "quit", "cd", "set", "sort", "theme", "symbols", "git", "help",
                     ];
                     for cmd in &commands {
                         if cmd.starts_with(input.as_str()) {
@@ -1519,8 +1547,57 @@ fn execute_command(app: &mut App, cmd: &str) {
                 app.error = Some(("USAGE: untag <name>".to_string(), Instant::now()));
             }
         }
+        Some("git") => {
+            if let Some(subcmd) = parts.get(1) {
+                let git_parts: Vec<&str> = subcmd.trim().splitn(2, ' ').collect();
+                match git_parts.first().copied() {
+                    Some("status") => {
+                        let dir = app.pane().current_dir.clone();
+                        app.git_file_statuses = crate::gitstatus::parse_git_status(&dir);
+                        let count = app.git_file_statuses.len();
+                        app.error = Some((format!("GIT: {} CHANGES DETECTED", count), Instant::now()));
+                    }
+                    Some("add") => {
+                        let dir = app.pane().current_dir.clone();
+                        match crate::gitstatus::git_stage(&dir, ".") {
+                            Ok(()) => app.error = Some(("GIT: ALL STAGED".to_string(), Instant::now())),
+                            Err(e) => app.error = Some((e, Instant::now())),
+                        }
+                        app.git_file_statuses = crate::gitstatus::parse_git_status(&dir);
+                    }
+                    Some("reset") => {
+                        let dir = app.pane().current_dir.clone();
+                        match crate::gitstatus::git_unstage(&dir, ".") {
+                            Ok(()) => app.error = Some(("GIT: ALL UNSTAGED".to_string(), Instant::now())),
+                            Err(e) => app.error = Some((e, Instant::now())),
+                        }
+                        app.git_file_statuses = crate::gitstatus::parse_git_status(&dir);
+                    }
+                    Some("commit") => {
+                        if let Some(msg) = git_parts.get(1) {
+                            let dir = app.pane().current_dir.clone();
+                            match crate::gitstatus::git_commit(&dir, msg) {
+                                Ok(out) => {
+                                    let display = if out.len() > 60 { format!("{}…", &out[..59]) } else { out };
+                                    app.error = Some((format!("COMMITTED: {}", display), Instant::now()));
+                                }
+                                Err(e) => app.error = Some((e, Instant::now())),
+                            }
+                            app.git_file_statuses = crate::gitstatus::parse_git_status(&dir);
+                        } else {
+                            app.error = Some(("USAGE: git commit <message>".to_string(), Instant::now()));
+                        }
+                    }
+                    _ => {
+                        app.error = Some(("GIT: status|add|reset|commit".to_string(), Instant::now()));
+                    }
+                }
+            } else {
+                app.error = Some(("USAGE: git <status|add|reset|commit>".to_string(), Instant::now()));
+            }
+        }
         Some("help") => {
-            app.error = Some(("COMMANDS: q cd set sort theme symbols shell tag untag help".to_string(), Instant::now()));
+            app.error = Some(("COMMANDS: q cd set sort theme symbols shell tag untag git help".to_string(), Instant::now()));
         }
         _ => {
             app.error = Some(("UNKNOWN COMMAND \u{2014} TYPE :help".to_string(), Instant::now()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod app;
 mod archive;
 mod config;
 mod favorites;
+mod gitstatus;
 mod highlight;
 mod input;
 mod logo;

--- a/src/nav.rs
+++ b/src/nav.rs
@@ -130,6 +130,8 @@ impl App {
             }
         }
         self.rebuild_filtered();
+        // Refresh git file statuses (#82)
+        self.git_file_statuses = crate::gitstatus::parse_git_status(&self.pane().current_dir);
     }
 
     pub fn rebuild_filtered(&mut self) {

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -272,6 +272,7 @@ fn collect_hints(app: &App) -> Vec<(&'static str, &'static str)> {
                 h.push(("^Z", "undo"));
             }
             h.push(("^T", "tag"));
+            h.push(("^G", "git stage"));
             h.push((":", "command"));
             h.push(("^F", "fav"));
             h.push(("L", "lock"));

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -325,6 +325,18 @@ pub fn render_pane(f: &mut Frame, app: &App, pane_idx: usize, area: Rect) {
             }
         }
 
+        // Git status badge (#82)
+        if let Some(status) = app.git_file_statuses.get(&entry.name) {
+            let (badge, color) = match status {
+                crate::gitstatus::GitFileStatus::Added => ("[+]", pal.text_hot),
+                crate::gitstatus::GitFileStatus::Modified => ("[M]", pal.text_mid),
+                crate::gitstatus::GitFileStatus::Untracked => ("[?]", pal.text_dim),
+                crate::gitstatus::GitFileStatus::Staged => ("[S]", pal.text_hot),
+                crate::gitstatus::GitFileStatus::Conflict => ("[!]", pal.warn),
+            };
+            spans.push(Span::styled(badge, Style::default().fg(color).bg(row_bg)));
+        }
+
         // Type badge
         if show_type {
             let badge = file_type_badge(entry);


### PR DESCRIPTION
## Summary
- Git status badges in file list (Added/Modified/Untracked/Staged/Conflict)
- Ctrl+G to stage/unstage files
- :git command with stage/unstage/commit subcommands

## Test plan
- [ ] Open rem in a git repo with modified files
- [ ] Verify status badges appear next to files
- [ ] Ctrl+G to stage a file, verify badge updates
- [ ] :git commit "message" to commit staged files

🤖 Generated with [Claude Code](https://claude.com/claude-code)