### PR TITLE
Add frecency-scored smart bookmarks (#84)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -713,6 +713,8 @@ pub struct App {
     // File tagging (#58)
     pub tags: crate::tags::TagStore,
     pub tag_input: String,
+    // Frecency smart bookmarks (#84)
+    pub frecency: crate::frecency::FrecencyStore,
 }
 
 impl App {
@@ -806,6 +808,7 @@ impl App {
             undo_stack: Vec::new(),
             tags: crate::tags::TagStore::new(),
             tag_input: String::new(),
+            frecency: crate::frecency::FrecencyStore::new(),
         };
         app.load_entries();
         app.git_info = GitInfo::detect(&app.panes[0].current_dir);

--- a/src/frecency.rs
+++ b/src/frecency.rs
@@ -1,0 +1,59 @@
+use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct FrecencyEntry {
+    pub visits: u32,
+    pub last_visit: u64, // days since epoch
+}
+
+#[derive(Serialize, Deserialize, Default, Clone)]
+pub struct FrecencyStore {
+    entries: HashMap<String, FrecencyEntry>,
+}
+
+impl FrecencyStore {
+    pub fn new() -> Self { Self::default() }
+
+    pub fn record_visit(&mut self, path: &str) {
+        let today = now_days();
+        let entry = self.entries.entry(path.to_string()).or_insert(FrecencyEntry { visits: 0, last_visit: today });
+        entry.visits += 1;
+        entry.last_visit = today;
+    }
+
+    pub fn top_dirs(&self, n: usize) -> Vec<(String, f64)> {
+        let today = now_days();
+        let mut scored: Vec<(String, f64)> = self.entries.iter()
+            .map(|(k, e)| {
+                let days_since = today.saturating_sub(e.last_visit) as f64;
+                let score = e.visits as f64 * (1.0 / (1.0 + days_since * 0.1));
+                (k.clone(), score)
+            })
+            .collect();
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        scored.truncate(n);
+        scored
+    }
+
+    pub fn load() -> Self {
+        let Some(path) = frecency_path() else { return Self::new() };
+        std::fs::read_to_string(path).ok()
+            .and_then(|c| toml::from_str(&c).ok())
+            .unwrap_or_default()
+    }
+
+    pub fn save(&self) {
+        let Some(path) = frecency_path() else { return };
+        if let Some(parent) = path.parent() { let _ = std::fs::create_dir_all(parent); }
+        if let Ok(content) = toml::to_string(self) { let _ = std::fs::write(path, content); }
+    }
+}
+
+fn frecency_path() -> Option<std::path::PathBuf> {
+    dirs::config_dir().map(|d| d.join("rem").join("frecency.toml"))
+}
+fn now_days() -> u64 {
+    SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs() / 86400).unwrap_or(0)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod app;
 mod archive;
 mod config;
 mod favorites;
+mod frecency;
 mod highlight;
 mod input;
 mod logo;
@@ -83,6 +84,9 @@ fn main() -> io::Result<()> {
     // Load tags (#58)
     app.tags = tags::load_tags();
 
+    // Load frecency (#84)
+    app.frecency = frecency::FrecencyStore::load();
+
     // Setup terminal
     terminal::enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -108,6 +112,9 @@ fn main() -> io::Result<()> {
     } else {
         execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
     }
+
+    // Save frecency (#84)
+    app.frecency.save();
 
     // Save bookmarks
     marks::save_marks(&app.marks);

--- a/src/nav.rs
+++ b/src/nav.rs
@@ -169,6 +169,7 @@ impl App {
         }
         self.load_entries();
         self.git_info = GitInfo::detect(&dir);
+        self.frecency.record_visit(&dir.to_string_lossy());
         if !self.reduce_motion {
             self.anim_frame = 1;
             self.anim_tick = Instant::now();

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -264,6 +264,35 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
         }
     }
 
+    // Frecency section (#84)
+    {
+        let top = app.frecency.top_dirs(5);
+        if !top.is_empty() {
+            lines.push(Line::from(Span::raw("")));
+            lines.push(Line::from(Span::styled(
+                " F R E Q U E N T",
+                Style::default().fg(pal.text_dim).bg(pal.bg),
+            )));
+            for (path_str, _score) in &top {
+                let dir_name = std::path::Path::new(path_str)
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| path_str.clone());
+                let max_w = width.saturating_sub(4);
+                let display = if dir_name.chars().count() > max_w {
+                    let t: String = dir_name.chars().take(max_w.saturating_sub(1)).collect();
+                    format!("{}\u{2026}", t)
+                } else {
+                    dir_name
+                };
+                lines.push(Line::from(Span::styled(
+                    format!(" {}", display),
+                    Style::default().fg(pal.text_mid).bg(pal.bg),
+                )));
+            }
+        }
+    }
+
     // Pad to fill area
     let height = area.height as usize;
     while lines.len() < height {


### PR DESCRIPTION
## Summary
- Tracks directory visit frequency + recency with score formula
- Shows top 5 frequent directories in sidebar FREQUENT section
- Persists to ~/.config/rem/frecency.toml

## Test plan
- [ ] Navigate between directories, verify frecency.toml updates
- [ ] Check sidebar shows FREQUENT section with visited dirs
- [ ] Verify scoring favors recently + frequently visited dirs

🤖 Generated with [Claude Code](https://claude.com/claude-code)