### PR TITLE
Add configurable header ticker (#88)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -713,6 +713,10 @@ pub struct App {
     // File tagging (#58)
     pub tags: crate::tags::TagStore,
     pub tag_input: String,
+    // Header ticker (#88)
+    pub ticker_messages: Vec<String>,
+    pub ticker_offset: usize,
+    pub ticker_enabled: bool,
 }
 
 impl App {
@@ -806,6 +810,15 @@ impl App {
             undo_stack: Vec::new(),
             tags: crate::tags::TagStore::new(),
             tag_input: String::new(),
+            ticker_messages: vec![
+                "BUILDING BETTER WORLDS".to_string(),
+                "COMPANY PROPERTY — DO NOT DUPLICATE".to_string(),
+                "WEYLAND-YUTANI CORP — EST. 2099".to_string(),
+                "SCIENCE IN THE SERVICE OF MANKIND".to_string(),
+                "OUR BUSINESS IS LIFE ITSELF".to_string(),
+            ],
+            ticker_offset: 0,
+            ticker_enabled: true,
         };
         app.load_entries();
         app.git_info = GitInfo::detect(&app.panes[0].current_dir);
@@ -969,6 +982,10 @@ impl App {
         }
         // CRT glitch (#15)
         self.glitch_tick = self.glitch_tick.wrapping_add(1);
+        // Header ticker scroll (#88)
+        if self.ticker_enabled && self.glitch_tick % 3 == 0 {
+            self.ticker_offset = self.ticker_offset.wrapping_add(1);
+        }
         // Green phosphor trail: track cursor movement, decay ghosts
         let current_cursor = self.pane().cursor;
         if current_cursor != self.prev_cursor_pos {

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,14 @@ struct ConfigFile {
     appearance: AppearanceConfig,
     #[serde(default)]
     behavior: BehaviorConfig,
+    #[serde(default)]
+    ticker: TickerConfig,
+}
+
+#[derive(Deserialize, Default)]
+struct TickerConfig {
+    enabled: Option<bool>,
+    messages: Option<Vec<String>>,
 }
 
 #[derive(Deserialize, Default)]
@@ -42,6 +50,8 @@ pub struct Config {
     pub glitch_enabled: bool,
     pub mouse_enabled: bool,
     pub warnings: Vec<String>,
+    pub ticker_enabled: bool,
+    pub ticker_messages: Vec<String>,
 }
 
 impl Default for Config {
@@ -57,6 +67,8 @@ impl Default for Config {
             glitch_enabled: true,
             mouse_enabled: true,
             warnings: Vec::new(),
+            ticker_enabled: true,
+            ticker_messages: Vec::new(), // empty = use app defaults
         }
     }
 }
@@ -223,6 +235,15 @@ impl Config {
                                 SortMode::NameAsc
                             }
                         };
+                    }
+                    // Ticker config (#88)
+                    if let Some(v) = file.ticker.enabled {
+                        cfg.ticker_enabled = v;
+                    }
+                    if let Some(msgs) = file.ticker.messages {
+                        if !msgs.is_empty() {
+                            cfg.ticker_messages = msgs;
+                        }
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,10 @@ fn main() -> io::Result<()> {
     app.reduce_motion = cfg.reduce_motion;
     app.glitch_enabled = cfg.glitch_enabled;
     app.mouse_enabled = cfg.mouse_enabled;
+    app.ticker_enabled = cfg.ticker_enabled;
+    if !cfg.ticker_messages.is_empty() {
+        app.ticker_messages = cfg.ticker_messages;
+    }
     app.load_entries(); // re-sort with configured sort mode
 
     // Show config warnings

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -14,13 +14,18 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
     let item_count = pane.entries.len();
     let mark_count = app.visual_marks.len();
 
-    // Split header: left (status) | right (logo)
-    let badge_width = logo::HEADER_BADGE.chars().count() as u16 + 2;
+    // Split header: left (status) | right (logo/ticker)
+    let right_width = if app.ticker_enabled && !app.ticker_messages.is_empty() {
+        // Give ticker a proportional share of the header
+        (area.width / 3).max(20)
+    } else {
+        logo::HEADER_BADGE.chars().count() as u16 + 2
+    };
     let halves = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
             Constraint::Min(30),
-            Constraint::Length(badge_width),
+            Constraint::Length(right_width),
         ])
         .split(area);
 
@@ -185,31 +190,51 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
     let left_para = Paragraph::new(Line::from(spans)).block(left_block);
     f.render_widget(left_para, halves[0]);
 
-    // Right side: corporate badge
-    let logo_spans = vec![
-        Span::styled(
-            app.symbols.mark,
-            Style::default().fg(pal.border_hot).bg(pal.surface),
-        ),
-        Span::styled(
-            " WEYLAND-YUTANI ",
-            Style::default().fg(pal.text_mid).bg(pal.surface),
-        ),
-        Span::styled(
-            "CORP ",
-            Style::default().fg(pal.text_hot).bg(pal.surface)
-                .add_modifier(Modifier::BOLD),
-        ),
-    ];
+    // Right side: ticker or corporate badge (#88)
+    if app.ticker_enabled && !app.ticker_messages.is_empty() {
+        // Build concatenated ticker text with separators
+        let separator = " \u{00b7} ";
+        let full_text: String = app.ticker_messages.join(separator);
+        let full_len = full_text.chars().count();
+        let display_width = halves[1].width.saturating_sub(2) as usize;
 
-    let right_block = Block::default()
-        .borders(Borders::BOTTOM)
-        .border_type(BorderType::Plain)
-        .border_style(Style::default().fg(pal.border_mid))
-        .style(Style::default().bg(pal.surface));
+        if full_len > 0 {
+            // Scrolling window into the text (wrapping)
+            let doubled = format!("{}{}{}", full_text, separator, full_text);
+            let offset = app.ticker_offset % (full_len + separator.chars().count());
+            let visible: String = doubled.chars().skip(offset).take(display_width).collect();
 
-    let right_para = Paragraph::new(Line::from(logo_spans))
-        .block(right_block)
-        .alignment(ratatui::layout::Alignment::Right);
-    f.render_widget(right_para, halves[1]);
+            let ticker_spans = vec![
+                Span::styled(
+                    format!(" {}", visible),
+                    Style::default().fg(pal.text_dim).bg(pal.surface),
+                ),
+            ];
+            let right_block = Block::default()
+                .borders(Borders::BOTTOM)
+                .border_type(BorderType::Plain)
+                .border_style(Style::default().fg(pal.border_mid))
+                .style(Style::default().bg(pal.surface));
+            let right_para = Paragraph::new(Line::from(ticker_spans))
+                .block(right_block)
+                .alignment(ratatui::layout::Alignment::Right);
+            f.render_widget(right_para, halves[1]);
+        }
+    } else {
+        // Original corporate badge
+        let logo_spans = vec![
+            Span::styled(app.symbols.mark, Style::default().fg(pal.border_hot).bg(pal.surface)),
+            Span::styled(" WEYLAND-YUTANI ", Style::default().fg(pal.text_mid).bg(pal.surface)),
+            Span::styled("CORP ", Style::default().fg(pal.text_hot).bg(pal.surface).add_modifier(Modifier::BOLD)),
+        ];
+        let right_block = Block::default()
+            .borders(Borders::BOTTOM)
+            .border_type(BorderType::Plain)
+            .border_style(Style::default().fg(pal.border_mid))
+            .style(Style::default().bg(pal.surface));
+        let right_para = Paragraph::new(Line::from(logo_spans))
+            .block(right_block)
+            .alignment(ratatui::layout::Alignment::Right);
+        f.render_widget(right_para, halves[1]);
+    }
 }


### PR DESCRIPTION
## Summary
- Scrolling message ticker in header bar
- Configurable messages via config.toml [ticker] section
- Auto-scrolls with WY-lore default messages

## Test plan
- [ ] Run rem, verify ticker scrolls in header
- [ ] Add [ticker] section to config.toml with custom messages
- [ ] Verify custom messages appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)